### PR TITLE
set motion_possible to true only of robot can be actually moved

### DIFF
--- a/ur_robot_driver/src/ros/hardware_interface.cpp
+++ b/ur_robot_driver/src/ros/hardware_interface.cpp
@@ -695,9 +695,13 @@ void HardwareInterface::extractRobotStatus()
   {
     robot_status_resource_.motion_possible = TriState::FALSE;
   }
-  else
+  else if (robot_mode_ == ur_dashboard_msgs::RobotMode::RUNNING || robot_mode_ == ur_dashboard_msgs::RobotMode::BACKDRIVE)
   {
     robot_status_resource_.motion_possible = TriState::TRUE;
+  }
+  else
+  {
+    robot_status_resource_.motion_possible = TriState::FALSE;
   }
 
   // the error code, if any, is not transmitted by this protocol

--- a/ur_robot_driver/src/ros/hardware_interface.cpp
+++ b/ur_robot_driver/src/ros/hardware_interface.cpp
@@ -695,7 +695,8 @@ void HardwareInterface::extractRobotStatus()
   {
     robot_status_resource_.motion_possible = TriState::FALSE;
   }
-  else if (robot_mode_ == ur_dashboard_msgs::RobotMode::RUNNING || robot_mode_ == ur_dashboard_msgs::RobotMode::BACKDRIVE)
+  else if (robot_mode_ == ur_dashboard_msgs::RobotMode::RUNNING ||
+           robot_mode_ == ur_dashboard_msgs::RobotMode::BACKDRIVE)
   {
     robot_status_resource_.motion_possible = TriState::TRUE;
   }

--- a/ur_robot_driver/src/ros/hardware_interface.cpp
+++ b/ur_robot_driver/src/ros/hardware_interface.cpp
@@ -695,8 +695,8 @@ void HardwareInterface::extractRobotStatus()
   {
     robot_status_resource_.motion_possible = TriState::FALSE;
   }
-  else if (robot_mode_ == ur_dashboard_msgs::RobotMode::RUNNING ||
-           robot_mode_ == ur_dashboard_msgs::RobotMode::BACKDRIVE)
+  else if (robot_mode_ == ur_dashboard_msgs::RobotMode::RUNNING)
+
   {
     robot_status_resource_.motion_possible = TriState::TRUE;
   }


### PR DESCRIPTION
I think it does make sense to add this little check. Otherwise `motion_possible` will be true also if the robot is actually switched off.